### PR TITLE
fix import furuta.robot if urdf dir doesn't exist

### DIFF
--- a/furuta/robot.py
+++ b/furuta/robot.py
@@ -7,13 +7,14 @@ import pinocchio as pin
 import serial
 
 
-@dataclass
 class RobotModel:
-    robot = None
-    robot = pin.RobotWrapper.BuildFromURDF(
-        "robot/hardware/v2/robot.urdf",
-        package_dirs=[str(Path("robot/hardware/v2/stl/").absolute())],
-    )
+    def __init__(self):
+        self.robot = None
+        base_path = Path("robot/hardware/v2/")
+        if base_path.exists():
+            urdf_path = str(base_path / "robot.urdf")
+            stls_path = str(base_path / "stl")
+            self.robot = pin.RobotWrapper.BuildFromURDF(urdf_path, [stls_path])
 
 
 class Robot:

--- a/scripts/replay_log.py
+++ b/scripts/replay_log.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     if args.type == "2D":
         viewer = Viewer2D()
     else:
-        viewer = Viewer3D(RobotModel.robot)
+        viewer = Viewer3D(RobotModel().robot)
 
     viewer.animate(times, states)
     viewer.close()

--- a/scripts/rollout.py
+++ b/scripts/rollout.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     state = State(0.0, 3.14, 0.0, 0.0)
 
     # Robot
-    robot = RobotModel.robot
+    robot = RobotModel().robot
 
     # Create the simulation
     sim_state = np.array(


### PR DESCRIPTION
As the robot folder containing the urdf and stls is not inside the package, when you tried to import from furuta.robot there was an error because the path didn't exist.